### PR TITLE
fix test-date.R error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -72,7 +72,8 @@ Suggests:
     magrittr,
     rmarkdown,
     testthat (>= 3.0.0),
-    vdiffr
+    vdiffr,
+    withr
 VignetteBuilder: 
     knitr
 Config/testthat/edition: 3

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -1,5 +1,7 @@
 test_that("Mean Ceramic Date", {
   skip_if_not_installed("folio")
+  skip_if_not_installed("withr")
+  withr::local_options(list(max.print = 1e6))
   data("zuni", package = "folio")
   counts <- arkhe::as_count(zuni)
 


### PR DESCRIPTION
Fixed the failing test that got the package pulled from CRAN. 

## Description
Increased the `max.print` option in https://github.com/tesselle/tabula/blob/master/tests/testthat/test-date.R to fix the snapshot test for `dt`, which was failing due to `[ reached 'max' / getOption("max.print") -- omitted 418 rows ]` in the output not matching up with the snapshot. I used the ` local_options()` function in `withr` to temporarily increase `max.print` just in this test, so I also added `withr` to Suggests in DESCRIPTION. `devtools::check()` runs with 0 errors, warnings, or notes.
